### PR TITLE
Add ibrun to mpirun options

### DIFF
--- a/tst/regression/run_tests.py
+++ b/tst/regression/run_tests.py
@@ -268,7 +268,7 @@ if __name__ == '__main__':
     parser.add_argument('--mpirun',
                         default='mpirun',
                         # 2x MPI, Slurm, PBS/Torque, LSF, Cray ALPS
-                        choices=['mpirun', 'mpiexec', 'srun', 'qsub', 'lsrun', 'aprun'],
+                        choices=['mpirun', 'mpiexec', 'srun', 'qsub', 'lsrun', 'aprun', 'ibrun'],
                         help='change MPI run wrapper command (e.g. for job schedulers)')
 
     parser.add_argument('--mpirun_opts',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Prerequisite checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] My code follows the Athena++ [Style Guide](https://github.com/PrincetonUniversity/athena/wiki/Style-Guide)
- [ ] All new and existing tests passed.  (I don't see why they wouldn't)

Please review the [`CONTRIBUTING.md`](../blob/master/CONTRIBUTING.md) file for detailed guidelines.

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Stampede3 uses `ibrun` in place of `mpirun` so this pull request allows for that.
